### PR TITLE
use_our_fork_on_docker_build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install setuptools==59.5.0
 
 # Install MMDetection
 RUN conda clean --all
-RUN git clone https://github.com/open-mmlab/mmdetection.git /mmdetection
+RUN git clone https://github.com/logivations/mmdetection.git /mmdetection
 WORKDIR /mmdetection
 ENV FORCE_CUDA="1"
 RUN pip install --no-cache-dir -r requirements/build.txt


### PR DESCRIPTION
As in [mmseg](https://github.com/logivations/mmsegmentation/blob/main/docker/Dockerfile#L34) build from our repo
Also now mmdetection `default` branch is `main`